### PR TITLE
 Enhance Event Features with RSVP Details and User Authorization

### DIFF
--- a/backend/pkg/handlers/groups/createEvent_handler.go
+++ b/backend/pkg/handlers/groups/createEvent_handler.go
@@ -3,8 +3,9 @@ package groups
 import (
 	"encoding/json"
 	"net/http"
-	"social-nework/pkg/models"
 	"time"
+
+	"social-nework/pkg/models"
 
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
@@ -12,6 +13,12 @@ import (
 
 // Create event
 func (gh *GroupHandler) CreateEvent(w http.ResponseWriter, r *http.Request) {
+	userID, ok := r.Context().Value("user_id").(string)
+	if !ok || userID == "" {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
 	vars := mux.Vars(r)
 	groupID := vars["groupId"]
 
@@ -20,6 +27,8 @@ func (gh *GroupHandler) CreateEvent(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Invalid JSON", http.StatusBadRequest)
 		return
 	}
+
+	event.CreatedBy = userID
 
 	// Check if user is member of the group
 	memberQuery := `SELECT id FROM group_members WHERE group_id = ? AND user_id = ? AND deleted_at IS NULL`

--- a/backend/pkg/handlers/groups/getGroupEvent_handler.go
+++ b/backend/pkg/handlers/groups/getGroupEvent_handler.go
@@ -3,6 +3,7 @@ package groups
 import (
 	"encoding/json"
 	"net/http"
+
 	"social-nework/pkg/models"
 
 	"github.com/gorilla/mux"
@@ -10,9 +11,14 @@ import (
 
 // Get group events
 func (gh *GroupHandler) GetGroupEvents(w http.ResponseWriter, r *http.Request) {
+	userID, ok := r.Context().Value("user_id").(string)
+	if !ok || userID == "" {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
 	vars := mux.Vars(r)
 	groupID := vars["groupId"]
-	userID := r.URL.Query().Get("user_id")
 
 	// Check if user is member of the group
 	memberQuery := `SELECT id FROM group_members WHERE group_id = ? AND user_id = ? AND deleted_at IS NULL`

--- a/backend/pkg/handlers/groups/getGroupEvent_handler.go
+++ b/backend/pkg/handlers/groups/getGroupEvent_handler.go
@@ -3,13 +3,11 @@ package groups
 import (
 	"encoding/json"
 	"net/http"
-
 	"social-nework/pkg/models"
-
 	"github.com/gorilla/mux"
 )
 
-// Get group events
+// Get group events with RSVP details
 func (gh *GroupHandler) GetGroupEvents(w http.ResponseWriter, r *http.Request) {
 	userID, ok := r.Context().Value("user_id").(string)
 	if !ok || userID == "" {
@@ -29,10 +27,27 @@ func (gh *GroupHandler) GetGroupEvents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	query := `SELECT id, group_id, title, description, location, start_time, end_time, created_by, created_at, updated_at 
-			  FROM events WHERE group_id = ? AND deleted_at IS NULL ORDER BY start_time ASC`
+	// Get events with attendee count
+	eventQuery := `
+		SELECT 
+			e.id, 
+			e.group_id, 
+			e.title, 
+			e.description, 
+			e.location, 
+			e.start_time, 
+			e.end_time, 
+			e.created_by, 
+			e.created_at, 
+			e.updated_at,
+			COALESCE(COUNT(ea.id), 0) as attendee_count
+		FROM events e
+		LEFT JOIN event_attendees ea ON e.id = ea.event_id AND ea.deleted_at IS NULL
+		WHERE e.group_id = ? AND e.deleted_at IS NULL 
+		GROUP BY e.id
+		ORDER BY e.start_time ASC`
 
-	rows, err := gh.db.Query(query, groupID)
+	rows, err := gh.db.Query(eventQuery, groupID)
 	if err != nil {
 		http.Error(w, "Failed to fetch events", http.StatusInternalServerError)
 		return
@@ -40,15 +55,92 @@ func (gh *GroupHandler) GetGroupEvents(w http.ResponseWriter, r *http.Request) {
 	defer rows.Close()
 
 	var events []models.Event
+	var eventIDs []string
+
+	// First, collect all events and their IDs
 	for rows.Next() {
 		var event models.Event
-		err := rows.Scan(&event.ID, &event.GroupID, &event.Title, &event.Description,
-			&event.Location, &event.StartTime, &event.EndTime, &event.CreatedBy,
-			&event.CreatedAt, &event.UpdatedAt)
+		err := rows.Scan(
+			&event.ID, 
+			&event.GroupID, 
+			&event.Title, 
+			&event.Description,
+			&event.Location, 
+			&event.StartTime, 
+			&event.EndTime, 
+			&event.CreatedBy,
+			&event.CreatedAt, 
+			&event.UpdatedAt,
+			&event.AttendeeCount,
+		)
 		if err != nil {
 			continue
 		}
 		events = append(events, event)
+		eventIDs = append(eventIDs, event.ID)
+	}
+
+	// If we have events, get all RSVP details for these events
+	if len(eventIDs) > 0 {
+		// Create placeholders for IN clause
+		placeholders := ""
+		args := []interface{}{}
+		for i, eventID := range eventIDs {
+			if i > 0 {
+				placeholders += ","
+			}
+			placeholders += "?"
+			args = append(args, eventID)
+		}
+
+		// Get attendee details for all events
+		attendeeQuery := `
+			SELECT 
+				ea.id,
+				ea.event_id,
+				ea.user_id,
+				COALESCE(u.first_name || ' ' || u.last_name, u.nickname, 'Unknown User') as user_name,
+				ea.status,
+				ea.created_at as joined_at
+			FROM event_attendees ea
+			JOIN users u ON ea.user_id = u.id
+			WHERE ea.event_id IN (` + placeholders + `) AND ea.deleted_at IS NULL
+			ORDER BY ea.created_at ASC`
+
+		attendeeRows, err := gh.db.Query(attendeeQuery, args...)
+		if err != nil {
+			http.Error(w, "Failed to fetch attendee details", http.StatusInternalServerError)
+			return
+		}
+		defer attendeeRows.Close()
+
+		// Group attendees by event ID
+		eventAttendees := make(map[string][]models.EventAttendee)
+		for attendeeRows.Next() {
+			var attendee models.EventAttendee
+			var eventID string
+			err := attendeeRows.Scan(
+				&attendee.ID,
+				&eventID,
+				&attendee.UserID,
+				&attendee.UserName,
+				&attendee.Status,
+				&attendee.JoinedAt,
+			)
+			if err != nil {
+				continue
+			}
+			eventAttendees[eventID] = append(eventAttendees[eventID], attendee)
+		}
+
+		// Attach attendee details to events
+		for i := range events {
+			if attendees, exists := eventAttendees[events[i].ID]; exists {
+				events[i].Attendees = attendees
+			} else {
+				events[i].Attendees = []models.EventAttendee{} // Empty slice instead of nil
+			}
+		}
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/backend/pkg/handlers/groups/rsvpEvent_handler.go
+++ b/backend/pkg/handlers/groups/rsvpEvent_handler.go
@@ -12,6 +12,12 @@ import (
 
 // RSVP to event
 func (gh *GroupHandler) RSVPEvent(w http.ResponseWriter, r *http.Request) {
+	userID, ok := r.Context().Value("user_id").(string)
+	if !ok || userID == "" {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
 	vars := mux.Vars(r)
 	eventID := vars["eventId"]
 
@@ -20,6 +26,8 @@ func (gh *GroupHandler) RSVPEvent(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Invalid JSON", http.StatusBadRequest)
 		return
 	}
+
+	attendee.UserID = userID
 
 	// Check if user is member of the group that owns the event
 	memberQuery := `SELECT gm.id FROM group_members gm 

--- a/backend/pkg/models/models.go
+++ b/backend/pkg/models/models.go
@@ -95,14 +95,18 @@ type Event struct {
 	CreatedBy   string `json:"created_by"`
 	CreatedAt   int64  `json:"created_at"`
 	UpdatedAt   int64  `json:"updated_at"`
+	AttendeeCount int64 `json:"attendee_count"`
+	Attendees   []EventAttendee `json:"attendees"`
 }
 
 type EventAttendee struct {
 	ID        string `json:"id"`
 	EventID   string `json:"event_id"`
 	UserID    string `json:"user_id"`
+	UserName string `json:"user_name"`
 	Status    string `json:"status"` // going, maybe, not_going
 	CreatedAt int64  `json:"created_at"`
+	JoinedAt int64  `json:"joined_at"`
 }
 
 // Comment represents a comment on a post


### PR DESCRIPTION
### Description
This PR introduces several key improvements to enhance event management within groups:
### What was changed:

1. Enhanced GetGroupEvents handler

-  Now returns RSVP details and attendee count per event.

2. Extended Event model

-  Added AttendeesCount and Attendees fields to capture RSVP data.

3. RSVP Event Handler Update

- Now requires user authorization before a user can RSVP.

4. User Authorization

- Implemented across:
- RSVPEvent handler
- GetGroupEvents handler
-  CreateEvent handler

### Why these changes were made:

- To provide more context around each event by showing real-time RSVP and attendee data.
- To secure event operations by ensuring only authorized users can RSVP, create, or view group events.
 - To enhance user experience by giving more meaningful and relevant information per event.
 
 # How to Test:

    Ensure you have a valid user token for all requests involving RSVP, event creation, or event fetching.

1. GET /groups/{groupID}/events

-  Should return events with attendeesCount and a list of attendees for each.
-  Unauthorized requests should be rejected with a 401 error.

2. POST /groups/{groupID}/events/{eventID}/rsvp

- Should only succeed if the request has a valid user context.
- Duplicate RSVPs should be handled gracefully (either ignored or updated).

3. POST /groups/{groupID}/events

- Only authenticated users should be able to create an event.
- Events should include RSVP info upon fetching after creation.

closes #16 