### PR TITLE
 Fix backend route for unliking posts

### DIFF
--- a/backend/server.go
+++ b/backend/server.go
@@ -118,6 +118,7 @@ func main() {
 	router.HandleFunc("/posts/{comment_id}/like", auth.RequireAuth(handlers.LikeComment(db, notificationModel))).Methods(http.MethodPost)
 	router.HandleFunc("/posts/{post_id}/likes", auth.RequireAuth(handlers.GetPostLikes(db))).Methods(http.MethodGet)
 	router.HandleFunc("/users/{user_id}/likes", auth.RequireAuth(handlers.GetUserLikedPosts(db))).Methods(http.MethodGet)
+	router.HandleFunc("/posts/{post_id}/like", auth.RequireAuth(handlers.LikePost(db, notificationModel))).Methods(http.MethodDelete)
 
 	// Group Management Routes
 	router.HandleFunc("/api/groups", auth.RequireAuth(groupHandler.CreateGroup)).Methods("POST")


### PR DESCRIPTION
Description:

    Issue: The frontend "unlike" functionality was not working.

    Fix: Implemented the DELETE method for the /posts/{post_id}/like route in the backend to handle unliking posts.

    Effect: The "unlike" functionality is now working as expected on the frontend.

This change ensures the backend properly handles requests to unlike a post, which resolves the issue on the frontend.